### PR TITLE
Added version key to fix error in Home Assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # hacc-ozmo
-Home Assistant Custom Component for Ecovacs Deebot Ozmo 900
+Home Assistant Custom Component for Ecovacs Deebot Ozmo 900 
+
+Currently, this has been tested on the Ozmo 900 and N79
 
 With this Home Assistant Custom Component you'll be able to 
 * play/pause/stop

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# hacc-ozmo
-Home Assistant Custom Component for Ecovacs Deebot Ozmo 900 
+# hacc-deebot
+Home Assistant Custom Component for Ecovacs Deebot
 
 Currently, this has been tested on the Ozmo 900 and N79
 

--- a/custom_components/deebot/manifest.json
+++ b/custom_components/deebot/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "deebot",
   "name": "Ecovacs Deebot",
+  "version": "1.0",
   "documentation": "https://www.home-assistant.io/components/ecovacs",
   "requirements": [
     "ozmo==1.0.3"


### PR DESCRIPTION
Added version key to fix error in Home Assistant:

``
WARNING (MainThread) [homeassistant.loader] No 'version' key in the manifest file for custom integration 'deebot'. As of Home Assistant 2021.6, this integration will no longer be loaded. Please report this to the maintainer of 'deebot'�[0m
``