### PR TITLE
Fixes for Home Assistant 2022.2

### DIFF
--- a/custom_components/deebot/vacuum.py
+++ b/custom_components/deebot/vacuum.py
@@ -11,7 +11,7 @@ from homeassistant.components.vacuum import (
     STATE_PAUSED,
     STATE_RETURNING,
     SUPPORT_FAN_SPEED,
-    VacuumDevice,
+    VacuumEntity,
 )
 
 try:
@@ -315,7 +315,7 @@ class EcovacsDeebotVacuum(StateVacuumEntity):
         self.device.run(SetWaterLevel(level=level))
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the device-specific state attributes of this vacuum."""
         data = {}
         data[ATTR_ERROR] = self._error


### PR DESCRIPTION
Addresses #35 

I tested the changes at home with my vacuum. The component is again operational and there's no longer a `device_state_attributes` deprecation warning shown.