### PR TITLE
Fix for Home Assistant 2024.2

### DIFF
--- a/custom_components/deebot/vacuum.py
+++ b/custom_components/deebot/vacuum.py
@@ -11,7 +11,6 @@ from homeassistant.components.vacuum import (
     STATE_PAUSED,
     STATE_RETURNING,
     SUPPORT_FAN_SPEED,
-    VacuumEntity,
 )
 
 try:


### PR DESCRIPTION
VacuumEntity is a leftover from an old version and it not used in the code.
The VacuumEntity import make the code crash as the VacuumEntity was remove in HA 2024.2

It fix the issue #48 